### PR TITLE
Add trigger IsVisible

### DIFF
--- a/src/MicaWPF/Styles/Controls/ProgressRing.xaml
+++ b/src/MicaWPF/Styles/Controls/ProgressRing.xaml
@@ -76,9 +76,13 @@
                                 </controls:Arc>
                             </Grid>
                             <ControlTemplate.Triggers>
-                                <Trigger Property="IsEnabled" Value="True">
-                                    <Trigger.EnterActions>
-                                        <BeginStoryboard>
+                                <MultiTrigger>
+                                    <MultiTrigger.Conditions>
+                                        <Condition Property="IsEnabled" Value="True"/>
+                                        <Condition Property="IsVisible" Value="True"/>
+                                    </MultiTrigger.Conditions>
+                                    <MultiTrigger.EnterActions>
+                                        <BeginStoryboard Name="ProgressRing_StoryBoard">
                                             <Storyboard>
                                                 <DoubleAnimation
                                                     RepeatBehavior="Forever"
@@ -86,7 +90,6 @@
                                                     Storyboard.TargetProperty="(Canvas.RenderTransform).(RotateTransform.Angle)"
                                                     To="360"
                                                     Duration="0:0:0.65" />
-
                                                 <DoubleAnimation
                                                     AutoReverse="True"
                                                     RepeatBehavior="Forever"
@@ -97,13 +100,11 @@
                                                     Duration="0:0:1.3" />
                                             </Storyboard>
                                         </BeginStoryboard>
-                                    </Trigger.EnterActions>
-                                    <Trigger.ExitActions>
-                                        <BeginStoryboard>
-                                            <Storyboard />
-                                        </BeginStoryboard>
-                                    </Trigger.ExitActions>
-                                </Trigger>
+                                    </MultiTrigger.EnterActions>
+                                    <MultiTrigger.ExitActions>
+                                        <StopStoryboard BeginStoryboardName="ProgressRing_StoryBoard"/>
+                                    </MultiTrigger.ExitActions>
+                                </MultiTrigger>
                             </ControlTemplate.Triggers>
                         </ControlTemplate>
                     </Setter.Value>


### PR DESCRIPTION
Add trigger IsVisible to avoid ProgressRing running in background.

---
labels: Needs-Triage
assignees: Simnico99
---
# Description

Fixed that when Progress ring is set `IsIndeterminate=True` and `Visibility=Collapsed`, the animation still running in background. You can see the GPU usage in task manager.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
- [x] Test A
- [x] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
